### PR TITLE
UI server

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -38,6 +38,7 @@ export const InstanceIds = {
 ///////////////////////////////////////////////////////////////////
 
 export const agentIdFromKey = key => key
+export const uiIdFromHappId = happId => happId + '-ui'
 
 export const removeInstanceFromCallString = callString => {
   return callString.split('/').slice(1).join('/')

--- a/src/flows/install-happ.ts
+++ b/src/flows/install-happ.ts
@@ -135,7 +135,7 @@ export const setupInstances = async (client, {happId, agentId}) => {
   console.log("Instance setup successful!")
 }
 
-const lookupHoloApp = ({happId}: LookupHappRequest): Promise<HappEntry> => {
+export const lookupHoloApp = ({happId}: LookupHappRequest): Promise<HappEntry> => {
   // TODO: make actual call to HHA
   // this is a dummy response for now
   // assuming DNAs are served as JSON packages
@@ -145,6 +145,16 @@ const lookupHoloApp = ({happId}: LookupHappRequest): Promise<HappEntry> => {
     throw `happId not found in shim database: ${happId}`
   }
   return Promise.resolve(HAPP_DATABASE[happId])
+}
+
+export const listHoloApps = () => {
+  // TODO: call HHA's `get_my_registered_app` for real data
+  const fakeApps = Object.assign({}, HAPP_DATABASE)
+  for (const id in fakeApps) {
+    fakeApps[id].ui_hash = fakeApps[id].ui
+    fakeApps[id].dna_list = fakeApps[id].dnas
+  }
+  return Promise.resolve(fakeApps)
 }
 
 const downloadAppResources = async (happId): Promise<DownloadResult> => {

--- a/src/flows/install-happ.ts
+++ b/src/flows/install-happ.ts
@@ -4,7 +4,7 @@ import * as os from 'os'
 import * as path from 'path'
 
 import {HappID} from '../types'
-import {fail, unbundle} from '../common'
+import {fail, unbundle, uiIdFromHappId} from '../common'
 import * as Config from '../config'
 import {HAPP_DATABASE, HappResource, HappEntry} from '../shims/happ-server'
 
@@ -72,7 +72,7 @@ export const installDnasAndUi = async (client, opts: {happId: string, properties
 
   if (ui) {
     const uiResult = await client.call('admin/ui/install', {
-      id: `${happId}-ui`,
+      id: uiIdFromHappId(happId),
       root_dir: ui.path
     })
     results.concat([uiResult])

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,7 +7,7 @@
 import * as express from 'express'
 import {Client, Server as RpcServer} from 'rpc-websockets'
 
-import {agentIdFromKey} from './common'
+import {agentIdFromKey, uiIdFromHappId} from './common'
 import * as C from './config'
 import {zomeCall, installHapp, newAgent} from './flows'
 import {InstallHappRequest, listHoloApps} from './flows/install-happ'
@@ -79,15 +79,13 @@ export class IntrceptrServer {
 
     const happs = await listHoloApps()
     const uis = await masterClient.call('admin/ui/list')
-    const uisByHash = {}
+    const uisById = {}
 
     for (const ui of uis) {
-      uisByHash[ui.hash] = ui
+      uisById[ui.id] = ui
     }
-
     Object.keys(happs).forEach(happId => {
-      const uiHash = happs[happId].ui_hash
-      const ui = uisByHash[uiHash]
+      const ui = uisById[uiIdFromHappId(happId)]
       if (ui) {
         const dir = ui.root_dir
         const hash = ui.id  // TODO: eventually needs to be hApp hash!


### PR DESCRIPTION
Serves installed UIs over HTTP on the same port as the Websocket server. Each UI, if available, has an endpoint `/{happId}`, i.e. it's accessible at the ID for the hApp that it is a part of.