### PR TITLE
Add UI interfaces to config init script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,22 @@
       "dev": true,
       "requires": {
         "rpc-websockets": "^4.3.3"
+      },
+      "dependencies": {
+        "rpc-websockets": {
+          "version": "4.3.5",
+          "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-4.3.5.tgz",
+          "integrity": "sha512-hHOgJQbb/NYDqoFeRo5wrW1ICAmMSgWgEm2z5dillrEDf6ZTNiG8Cy/cE3cdHMacQiwIRKnZRbex/fJthzdyzw==",
+          "dev": true,
+          "requires": {
+            "assert-args": "^1.2.1",
+            "babel-runtime": "^6.26.0",
+            "circular-json": "^0.5.5",
+            "eventemitter3": "^3.1.0",
+            "uuid": "^3.3.2",
+            "ws": "^5.2.2"
+          }
+        }
       }
     },
     "@holochain/hcid-js": {

--- a/src/conductor.ts
+++ b/src/conductor.ts
@@ -60,10 +60,7 @@ export const spawnConductor = (baseDir) => {
   return conductor
 }
 
-const initialTomlConfig = (baseDir, {keyFile, publicAddress}) => {
-
-  // TODO: add DNA for HCHC when available
-  return `
+const initialTomlConfig = (baseDir, {keyFile, publicAddress}) => `
 bridges = []
 persistence_dir = "${baseDir}"
 signing_service_uri = "http://localhost:${Config.PORTS.wormhole}"
@@ -76,15 +73,15 @@ public_address = "${publicAddress}"
 
 
 [[dnas]]
-file = "${Config.DNAS.holoHosting.path}"
+file = "${Config.RESOURCES.holoHosting.dna.path}"
 id = "${Config.holoHostingAppId.dna}"
 
 [[dnas]]
-file = "${Config.DNAS.happStore.path}"
+file = "${Config.RESOURCES.happStore.dna.path}"
 id = "${Config.happStoreId.dna}"
 
 [[dnas]]
-file = "${Config.DNAS.holofuel.path}"
+file = "${Config.RESOURCES.holofuel.dna.path}"
 id = "${Config.holofuelId.dna}"
 
 
@@ -179,4 +176,3 @@ pattern = "^debug/dna"
 exclude = true
 pattern = ".*"
 `
-}

--- a/src/conductor.ts
+++ b/src/conductor.ts
@@ -141,6 +141,30 @@ port = ${Config.PORTS.internalInterface}
 type = "websocket"
 
 
+[[ui_bundles]]
+hash = 'Qm000'
+id = 'hha-ui'
+root_dir = '/home/michael/Holo/holo-hosting-app_GUI/ui'
+
+[[ui_interfaces]]
+bundle = 'hha-ui'
+dna_interface = 'master-interface'
+id = 'hha-ui-interface'
+port = 8800
+
+
+[[ui_bundles]]
+hash = 'Qm001'
+id = 'happ-store-ui'
+root_dir = '/home/michael/Holo/HApps-Store/ui'
+
+[[ui_interfaces]]
+bundle = 'happ-store-ui'
+dna_interface = 'master-interface'
+id = 'happ-store-ui-interface'
+port = 8880
+
+
 [logger]
 type = "debug"
 [[logger.rules.rules]]

--- a/src/conductor.ts
+++ b/src/conductor.ts
@@ -141,25 +141,25 @@ type = "websocket"
 [[ui_bundles]]
 hash = 'Qm000'
 id = 'hha-ui'
-root_dir = '/home/michael/Holo/holo-hosting-app_GUI/ui'
+root_dir = '${Config.RESOURCES.holoHosting.ui.path}'
 
 [[ui_interfaces]]
 bundle = 'hha-ui'
 dna_interface = 'master-interface'
 id = 'hha-ui-interface'
-port = 8800
+port = ${Config.RESOURCES.holoHosting.ui.port}
 
 
 [[ui_bundles]]
 hash = 'Qm001'
 id = 'happ-store-ui'
-root_dir = '/home/michael/Holo/HApps-Store/ui'
+root_dir = '${Config.RESOURCES.happStore.ui.path}'
 
 [[ui_interfaces]]
 bundle = 'happ-store-ui'
 dna_interface = 'master-interface'
 id = 'happ-store-ui-interface'
-port = 8880
+port = ${Config.RESOURCES.happStore.ui.port}
 
 
 [logger]

--- a/src/config/.gitignore
+++ b/src/config/.gitignore
@@ -1,1 +1,1 @@
-resource-config.ts
+user-config.ts

--- a/src/config/.gitignore
+++ b/src/config/.gitignore
@@ -1,1 +1,1 @@
-dna-config.ts
+resource-config.ts

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -124,14 +124,6 @@ const updateDnaConfigToUserConfig = (config: DnaConfigMap): UserConfig => {
   return {resources: newConfig}
 }
 
-let outdatedDnaConfig
-
-try {
-  outdatedDnaConfig = require('./dna-config').default
-} catch {
-  console.info("")
-}
-
 const readOutdatedDnaConfig = (): (DnaConfigMap | null) => {
   try {
     return require('./dna-config').default
@@ -141,8 +133,10 @@ const readOutdatedDnaConfig = (): (DnaConfigMap | null) => {
 }
 
 /**
- * Read the user-config.ts file, with the ability to
- * @type {[type]}
+ * Read the user-config.ts file, automatically migrating the old dna-config.ts file if
+ * applicable
+ *
+ * TODO: this can be simplified considerably once everyone is off of dna-config.ts
  */
 const readUserConfig = (): UserConfig => {
 
@@ -160,7 +154,7 @@ const readUserConfig = (): UserConfig => {
       if (testMode) {
         return testUserConfig
       } else {
-        const oudatedDnaConfig = readOutdatedDnaConfig()
+        const outdatedDnaConfig = readOutdatedDnaConfig()
         if (outdatedDnaConfig) {
           const userConfig = updateDnaConfigToUserConfig(outdatedDnaConfig)
           userConfig.resources.happStore.ui = {

--- a/src/flows/install-happ.ts
+++ b/src/flows/install-happ.ts
@@ -210,7 +210,7 @@ export const setupInstances = async (client, opts: {happId: string, agentId: str
 }
 
 export const setupServiceLogger = async (masterClient, {hostedHappId}) => {
-  const {path} = Config.DNAS.serviceLogger
+  const {path} = Config.RESOURCES.serviceLogger.dna
   const dnaId = serviceLoggerDnaIdFromHappId(hostedHappId)
   const instanceId = serviceLoggerInstanceIdFromHappId(hostedHappId)
   const agentId = Config.hostAgentName

--- a/src/scripts/build-happs.ts
+++ b/src/scripts/build-happs.ts
@@ -16,9 +16,9 @@ const hostedHapps: Array<AppBuildConfig> = [
   },
 ]
 
-const coreHapps = Object.values(Config.DNAS).map(entry => {
+const coreHapps = Object.values(Config.RESOURCES).map(entry => {
   // peel off two layers of directories to get to the actual dna source root
-  const dir = path.dirname(path.dirname(entry.path))
+  const dir = path.dirname(path.dirname(entry.dna.path))
   return {
     dnas: [dir],
     ui: null,

--- a/test/test-install-happ.ts
+++ b/test/test-install-happ.ts
@@ -145,7 +145,7 @@ sinonTest('can setup instances', async T => {
 sinonTest('can setup servicelogger', async T => {
   const {masterClient} = testEnvoyServer()
 
-  const serviceLogger = Config.DNAS.serviceLogger
+  const serviceLogger = Config.RESOURCES.serviceLogger.dna
   const happId = simpleApp.happId
   const dnaHash = simpleApp.dnas[0].hash
   const agentId = 'fake-agent-id'
@@ -185,7 +185,7 @@ sinonTest('can setup servicelogger', async T => {
 
 sinonTest('can perform entire installation flow', async T => {
   const {masterClient} = testEnvoyServer()
-  const serviceLogger = Config.DNAS.serviceLogger
+  const serviceLogger = Config.RESOURCES.serviceLogger.dna
   const happId = simpleApp.happId
   const dnaHash = simpleApp.dnas[0].hash
   const agentId = 'fake-agent-id'


### PR DESCRIPTION
## Breaking change

`dna-config.ts` is now named `user-config.ts`, and the format changes drastically. There is a helpful automatic migration that happens, but you will have to fill in the values of your UI directories in `user-config.ts`, which gets created for you automatically. You should:

1. Run `npm run init` again to generate a new config. This will also auto-migrate your `dna-config.ts` (if you have one) to `user-config.ts`
2. Edit `src/config/user-config.ts` and supply the built UI directories for the two apps shown. Or don't, and then you just won't have these UIs served.

When user-config is created properly, you will have two UI interfaces running in the conductor, one for Holo Hosting App, one for App Store, which are necessary for app installation and enabling (without using CLI tooling).